### PR TITLE
-d can accept a file path as an argument instead of always opening a file dialogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Takes screenshots and uploads them to puush using the puush API and copies the l
   - (in Ubuntu it's system settings > keyboard > keyboard shortcuts > custom shortcuts)
   - Log out for the changes to take place
   - Here's what it looks like for mine: ![Puush keyboard setup](http://puu.sh/cOyVz/8dcb1cd498.png)
-- If your linux install include Nemo File Manager (Such as Linux Mint), put puushFile.nemo_action in home/.local/share/nemo/actions
+- If your linux install includes Nemo File Manager (Such as Linux Mint), put puushFile.nemo_action in home/.local/share/nemo/actions
 
 ### Commands
 ``` bash

--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ Takes screenshots and uploads them to puush using the puush API and copies the l
   - (in Ubuntu it's system settings > keyboard > keyboard shortcuts > custom shortcuts)
   - Log out for the changes to take place
   - Here's what it looks like for mine: ![Puush keyboard setup](http://puu.sh/cOyVz/8dcb1cd498.png)
+- If your linux install include Nemo File Manager (Such as Linux Mint), put puushFile.nemo_action in home/.local/share/nemo/actions
 
 ### Commands
 ``` bash
 puush -a		# puush desktop
 puush -b		# area puush
 puush -c		# puush window
-puush -d		# file upload
+puush -d PATH	# file upload (Path optional)
 
 puush -h  	  # help
 ```

--- a/puush
+++ b/puush
@@ -66,12 +66,11 @@ function helpText ()
   printf "  -a                 puush entire desktop\n"
   printf "  -b                 select area to puush\n"
   printf "  -c                 puush current window\n"
-  printf "  -d                 puush specific file (opens file dialog)\n"
+  printf "  -d                 puush a file (Optional path)\n"
   printf "  -e                 puush clipboard contents\n"
   printf "\n"
   printf "  --help,-h          show this page\n"
   printf "\n"
-  printf "PATH:\n"
   printf "  PATH               optional: path of file to puush\n"
 }
 
@@ -118,8 +117,12 @@ case "$1" in
 
 	-d)
 		echo "File Upload"
+		if [ -z "$2" ]; then
 			fileName=`zenity --file-selection`
 			puushFile "$fileName"
+		else
+			puushFile "$2"
+		fi
 		;;
 
 	-e)

--- a/puushFile.nemo_action
+++ b/puushFile.nemo_action
@@ -1,0 +1,10 @@
+[Nemo Action]
+Active=true
+Name=Puush File
+Comment=Puush This File
+Exec=/usr/local/bin/puush/puush -d %F
+Icon-Name=image
+Selection=s
+Extensions=jpg;png;bmp;gif
+Terminal=false
+Quote=double


### PR DESCRIPTION
Using this, Puush Linux users can set their file browser up to upload a file directly from a right-click context menu, as in Windows.